### PR TITLE
Update Minecraft Fabric egg for Minecraft 1.20.5 and higher

### DIFF
--- a/Eggs-Pack/[🎮] Game Servers/Minecraft Servers/Java Minecraft/fabric/egg-fabric.json
+++ b/Eggs-Pack/[🎮] Game Servers/Minecraft Servers/Java Minecraft/fabric/egg-fabric.json
@@ -18,7 +18,8 @@
         "Java 11": "ghcr.io\/pterodactyl\/yolks:java_11",
         "Java 16": "ghcr.io\/pterodactyl\/yolks:java_16",
         "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
-        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18"
+        "Java 18": "ghcr.io\/pterodactyl\/yolks:java_18",
+        "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -Xmx{{SERVER_MEMORY}}M -jar {{SERVER_JARFILE}}",


### PR DESCRIPTION
Add Java 21, as fabric recommends it for Minecraft 1.20.5 and higher

https://fabricmc.net/2024/04/19/1205.html